### PR TITLE
C++11: Move Semantics: Access is allowed after casting to rvalue-reference.

### DIFF
--- a/lang/C++11.md
+++ b/lang/C++11.md
@@ -1109,7 +1109,6 @@ int main()
  
    cut.mf();					// cut is lvalue 
    std::move(cut).mf();			// cut now made rvalue through explicit calling of std::move
-   /// info: now you made 'cut' a rvalue - any access to 'cut' after std::move is undefined - do not touch 'cut' anymore
    Base().mf();					// Of course Base() is rvalue
     
    std::cout << "This is the end" << std::endl;


### PR DESCRIPTION
I have not been able to find documentation supporting the fact that access to an object after having cast its name to rvalue-reference leads to undefined behaviour.

The documentation for `std::move` precisely states the returned expression.

https://en.cppreference.com/w/cpp/utility/move does state: <<Unless otherwise specified, all standard library objects that have been moved from are placed in a "valid but unspecified state", meaning the object's class invariants hold (so functions without preconditions, such as the assignment operator, can be safely used on the object after it was moved from):  [...]>>,

but even so, "objects that have been moved from" are not the same as "object for which `std::move` has been called".