### PR TITLE
221225 cxx11 move semantics value category 01h

### DIFF
--- a/lang/C++11.md
+++ b/lang/C++11.md
@@ -1005,6 +1005,47 @@ auto spFoo = std::make_shared<Foo>();
 
 ## Move-Operator
 
+**Value category**
+
+Before C++11, a function-denoting-expression was an lvalue and an object-denoting-expression could be either an lvalue or an rvalue.
+
+Starting with C++11, a function-denoting-expression is an lvalue and an object-denoting-expression can be either an lvalue or an rvalue. This has not changed (but a new sub-category of rvalues exists).
+
+Originally, "lvalue" and "rvalue" were used to indicate whether an object-expression can appear on the left-hand-side of the assignment operator (then it is an lvalue) or can only appear on the right-hand-side of the assignment operator (then it is an rvalue).
+But that original definition is just a mnemonic and it is is not complete (has not been so for a long time).
+
+The fundamental value categories for object-denoting-expressions are
+lvalue (an expression which determines the identity of a "normal" object (which has a memory address)),
+prvalue ("pure rvalue" -- an expression used as operand to an operator or as initializer),
+and xvalue (an expression which determines the identity of an "expiring" object (which has a memory address)).
+
+A glvalue ("generalized lvalue") is an lvalue or an xvalue.
+An rvalue is an xvalue or a prvalue.
+
+Built-in operators specify the value categories for the operands and for the result.
+For example:
+- the assignment operator `=` expects an lvalue operand and a prvalue operand and produces an lvalue result;
+- the address-of unary operator `&` expects an lvalue operand and produces a prvalue result (the address of the operand).
+
+(We note that the address of the operand need not reside in normal memory for data -- it can be in a register, or an immediate operand to a machine-code instruction --, hence the result is not an lvalue.)
+
+But we often see that the right-hand-side of the (built-in) assignment operator is an lvalue itself, e.g. `int lhs; int rhs = ...; y = x;`. This is allowed. Whenever a prvalue is expected and a glvalue is provided, the "lvalue-to-rvalue conversion" (which might better be named the "glvalue-to-prvalue conversion") is applied, and it produces the contents of the glvalue.
+
+The opposite works as well, but only in some cases: whenever a glvalue is expected, but a prvalue is provided, the "temporary materialization conversion" is applied to convert the prvalue to an xvalue.
+Why have the words "only in some cases" been used in the last phrase ? Because we cannot bind lvalue-references-to-non-const to prvalues (lest we would end up with the possibility of modifying a temporary-i.e.-ephemeral object, and this is probably not what we mean, and the language is trying to help us), and lvalue-references form an important sub-category of lvalues.
+
+An xvalue can be produced by `static_cast`-ing to rvalue-reference or by calling a function which returns rvalue-reference (e.g. `std::move`) or (more rarely) by accessing a member or an element of another xvalue.
+So xvalues do not appear by themselves and actually require some effort from the programmer in order to exist.
+
+TODO: Write more and give examples.
+
+It is important to understand lvalues, xvalues and prvalues (and glvalues and rvalues) as a foundation for understanding move semantics and rvalue-references.
+We should go through the list of built-in operators, especially the function call operator. (User-defined operators are functions.)
+For the function call operator, we can read (https://timsong-cpp.github.io/cppwp/expr.call or https://www.eel.is/c++draft/expr.call):
+- A function call is an lvalue if the result type is an lvalue reference type or an rvalue reference to function type, an xvalue if the result type is an rvalue reference to object type, and a prvalue otherwise.
+
+
+
 **Copy-Semantik**
 
 ![img](file:///D:/Users/MStephan/AppData/Local/Temp/lu49729t3zx.tmp/lu49729t409_tmp_a08ded5ee984f960.png) 

--- a/lang/C++11.md
+++ b/lang/C++11.md
@@ -1186,7 +1186,7 @@ int main()
 	std::vector<int> vec1 = {1, 2, 3};
 	std::vector<int> vec2 = {4, 5, 6};
   
-	auto print = [](int& n){std::cout << " " << n;};
+	const auto print = [](int n){std::cout << " " << n;};
    
 	std::cout << "vec1: ";
 	std::for_each(vec1.begin(), vec1.end(), print);

--- a/lang/C++11.md
+++ b/lang/C++11.md
@@ -1109,13 +1109,13 @@ Die klassische Definition von *Lvalue* und *Rvalue* besagt, dass *Lvalue*-Werte 
 ```C++
 int getFour() { return 4;}
 
-int i = 1; 	// i ist Lvalue; 1 ist Rvalue
+int i = 1; 	// i ist Lvalue; 1 ist Prvalue
 
-int& lvalueRef = i; 	// lvalueRef ist Lvalue Referenz, i ist Lvalue
+int& lvalueRef = i; 	// lvalueRef ist Lvalue Referenz (Lvalue), i ist Lvalue
 
-int rvalue =  getFour();	// rvalue ist Lvalue; getFour() ist Rvalue
+int rvalue =  getFour();	// rvalue ist Lvalue; getFour() ist Prvalue
 
-// func ist Lvalue; Lambda-Funktion ist Rvalue  
+// func ist Lvalue; Lambda-Funktion ist Prvalue.
 auto func = [ ]{std::out << 2018 << std::endl;}	
 ```
 
@@ -1149,9 +1149,9 @@ int main()
    Base cut;
  
    cut.mf();					// cut is lvalue 
-   std::move(cut).mf();			// cut now made rvalue through explicit calling of std::move
+   std::move(cut).mf();			// cut now made rvalue (more exactly: xvalue) through explicit calling of std::move.
    /// info: now you made 'cut' a rvalue - any access to 'cut' after std::move is undefined - do not touch 'cut' anymore
-   Base().mf();					// Of course Base() is rvalue
+   Base().mf();					// Of course Base() is rvalue (more exactly: prvalue).
     
    std::cout << "This is the end" << std::endl;
 }


### PR DESCRIPTION
For copy semantics vs move semantics, I believe it is important to define the terms "lvalue", "prvalue" and "xvalue" (although my definitions might not be perfect -- discussing together is going to help, or please feel free to just correct my attempt) and then use the more exact terms and then discuss lvalue-references vs rvalue-references and move semantics.