### PR TITLE
C++11: std::endl replaced with '\n' (=> more efficient, avoids bad habit).

### DIFF
--- a/lang/C++11.md
+++ b/lang/C++11.md
@@ -93,7 +93,7 @@ int main()
     // resolved during compilation
     
     auto dd = 5 + d; 
-    std::cout << "Give " << dd << "Is double " << std::endl;
+    std::cout << "Give " << dd << "Is double\n";
         
     std::vector<int> vec {7, 5, 16, 18}; 
     for (auto item: vec)
@@ -284,8 +284,8 @@ int main()
    Point2D point2D{1, 2};       
    Point3D point3D{1, 2, 3};   
 
-   std::cout << "point2D: " << point2D.x << " " << point2D.y << std::endl;
-   std::cout << "point3D: " << point3D.x << " " << point3D.y << " " << point3D.z << std::endl;
+   std::cout << "point2D: " << point2D.x << " " << point2D.y << '\n';
+   std::cout << "point3D: " << point3D.x << " " << point3D.y << " " << point3D.z << '\n';
    
    return 0;
 }
@@ -309,11 +309,11 @@ int main()
 {
    std::initializer_list<int> int_list {5, 6, 7};  
     
-   std::cout << "initializer list size " << int_list.size() << std::endl;
+   std::cout << "initializer list size " << int_list.size() << '\n';
     
    for (int i: int_list)
    {
-      std::cout << "value " << i << std::endl;	
+      std::cout << "value " << i << '\n';
    }
    
    return 0;
@@ -500,7 +500,7 @@ ColorScoped favourite = ColorScoped::Blue;
 
 int main()
 {
-   std::cout << "Ma couleur préférée est " << static_cast<int>(favourite) << std::endl;
+   std::cout << "Ma couleur préférée est " << static_cast<int>(favourite) << '\n';
       
    return 0;
 }
@@ -531,7 +531,7 @@ int main()
    bool same_type = std::is_same< std::uint8_t, std::underlying_type_t<CharColor> >::value;
       
    std::cout << std::boolalpha;
-   std::cout << "is_same<unsigned char> " << same_type << std::endl;
+   std::cout << "is_same<unsigned char> " << same_type << '\n';
       
    return 0;
 }
@@ -570,10 +570,10 @@ int add(int s1, int s2) {return s1+s2;}
 int main()
 {  
    Result res = MyTypes::UNKNOWN;
-   std::cout << "result " << res << std::endl;
+   std::cout << "result " << res << '\n';
    
    func f = add;
-   std::cout << "func " << f(1, 1) << std::endl;
+   std::cout << "func " << f(1, 1) << '\n';
    
    return 0;
 }
@@ -606,22 +606,22 @@ void funcImpl(double d)
 {
 	if (d>10.0)
 	{
-		std::cout << "greater " << std::endl;
+		std::cout << "greater\n";
 	}
 	else
 	{
-		std::cout << "smaller " << std::endl;
+		std::cout << "smaller\n";
 	}    
 }
 
 int main()
 {
-   std::cout << "Hello, Wandbox!" << std::endl;
+   std::cout << "Hello, Wandbox!\n";
 
    myint32 i = 0;  
    myint32 j = 2;  
 	
-   std::cout << "vector = " << i+j << std::endl;
+   std::cout << "vector = " << i+j << '\n';
 	
    matchingService vec;
    vec.push_back(1);
@@ -632,7 +632,7 @@ int main()
    myarray<int> arr;
    arr.fill(4);
 
-   std::cout << "array = " << arr.front() << std::endl;
+   std::cout << "array = " << arr.front() << '\n';
 
    myfuncptr f = &(funcImpl);
    f(9);
@@ -772,14 +772,14 @@ int main()
    constexpr auto constexprSize = 3; // compile-time constant
    int size; 
    
-   std::cout << "constexpression " << constexprSize << std::endl;
+   std::cout << "constexpression " << constexprSize << '\n';
 
    // passt, da arraySize constexpr ist und der Compiler optimieren kann
    std::array<int, constexprSize> data = {1, 2, 3}; 
    
-   std::cout << "data0 " << data[0] << std::endl;
-   std::cout << "data1 " << data[1] << std::endl;
-   std::cout << "data2 " << data[2] << std::endl;
+   std::cout << "data0 " << data[0] << '\n';
+   std::cout << "data1 " << data[1] << '\n';
+   std::cout << "data2 " << data[2] << '\n';
    
    size = 3; 
    // Funzt. arraySize2 ist const-copy von size aber NICHT zur Compile-Zeit bekannt
@@ -788,7 +788,7 @@ int main()
    // Funzt nicht mit constexpr
    //constexpr auto arraySize3 = size; FEHLER
    
-   std::cout << "constsize " << arraySize2 << std::endl;
+   std::cout << "constsize " << arraySize2 << '\n';
    
    return 0;
 }
@@ -1075,7 +1075,7 @@ int& lvalueRef = i; 	// lvalueRef ist Lvalue Referenz, i ist Lvalue
 int rvalue =  getFour();	// rvalue ist Lvalue; getFour() ist Rvalue
 
 // func ist Lvalue; Lambda-Funktion ist Rvalue  
-auto func = [ ]{std::out << 2018 << std::endl;}	
+auto func = [ ]{std::out << 2018 << '\n';}
 ```
 
 Eine *Lvalue*-Referenz wird durch ein & hinter dem Datentyp erzeugt. Zwei && hingegen definieren eine *Rvalue*-Referenz.
@@ -1112,7 +1112,7 @@ int main()
    /// info: now you made 'cut' a rvalue - any access to 'cut' after std::move is undefined - do not touch 'cut' anymore
    Base().mf();					// Of course Base() is rvalue
     
-   std::cout << "This is the end" << std::endl;
+   std::cout << "This is the end\n";
 }
 
 ///> lvalue reference member function
@@ -1141,7 +1141,7 @@ template <typename T> void swapMove(T& a, T& b)
 
 int main()
 {
-	std::cout << "Hello, Martin" << std::endl;
+	std::cout << "Hello, Martin\n";
 	std::vector<int> vec1 = {1, 2, 3};
 	std::vector<int> vec2 = {4, 5, 6};
   
@@ -1150,24 +1150,24 @@ int main()
 	std::cout << "vec1: ";
 	std::for_each(vec1.begin(), vec1.end(), print);
 	std::cout << " &vec1 = " << &vec1[0];
-	std::cout << std::endl;
+	std::cout << '\n';
   
 	std::cout << "vec2: ";
 	std::for_each(vec2.begin(), vec2.end(), print);
 	std::cout << " &vec2 = " << &vec2[0];
-	std::cout << std::endl;
+	std::cout << '\n';
  
 	swapMove(vec1, vec2);
   
 	std::cout << "vec1: ";
 	std::for_each(vec1.begin(), vec1.end(), print);
 	std::cout << " &vec1 = " << &vec1[0];
-	std::cout << std::endl;
+	std::cout << '\n';
 	  
 	std::cout << "vec2: ";
 	std::for_each(vec2.begin(), vec2.end(), print);
 	std::cout << " &vec2 = " << &vec2[0];
-	std::cout << std::endl;
+	std::cout << '\n';
 }
 ```
 
@@ -1203,7 +1203,7 @@ using namespace std::literals::chrono_literals;
    
 int main()
 {
-	std::cout << "Hallo?" << std::endl;
+	std::cout << "Hallo?\n";
     
 	auto schoolHour = 45min;  
 	auto shortBreak = 300s;  
@@ -1215,8 +1215,8 @@ int main()
 
 	std::chrono::duration<double, std::ratio<3600>> schoolDayInHours = schoolDayInSeconds;  
  
-	std::cout << "School day in seconds: " << schoolDayInSeconds.count() << std::endl;
-	std::cout << "School day in hours: " << schoolDayInHours.count() << std::endl;     
+	std::cout << "School day in seconds: " << schoolDayInSeconds.count() << '\n';
+	std::cout << "School day in hours: " << schoolDayInHours.count() << '\n';
 }
 ```
 
@@ -1253,17 +1253,17 @@ void myFunction(int val)
 
 int main()
 {
-	std::cout << "Hallo" << std::endl;
+	std::cout << "Hallo\n";
  	std::vector<int> vecInt {1,2,3,4,5,6,7,8,9,10};  
 	int sum = 0;    
 
 	// summation with function  
 	std::for_each(vecInt.begin(), vecInt.end(), myFunction);    
-	std::cout << "Sum with Function: " << sumGlobal << std::endl;  
+	std::cout << "Sum with Function: " << sumGlobal << '\n';
  
 	// summation with lambda
 	std::for_each(vecInt.begin(), vecInt.end(), [&sum](int val){sum += val;});
-	std::cout << "Sum with Lambda: " << sum << std::endl;  
+	std::cout << "Sum with Lambda: " << sum << '\n';
 }
 ```
 
@@ -1278,7 +1278,7 @@ int main()
    auto addObj = [](int a, int b){ return a + b; };
    auto simple = []{};
    
-   std::cout << "résultat " << addObj(1, 1) << std::endl;
+   std::cout << "résultat " << addObj(1, 1) << '\n';
    
    // possible Lambda - but what the heck?
    simple();
@@ -1296,7 +1296,7 @@ struct Lambda
    {
       // Auf 's' kann zugegriffen werden 
       // '[=]' bewirkt eine implizite Bindung von this 
-      return [=] { std::cout << this->s << std::endl; }; 
+      return [=] { std::cout << this->s << '\n'; };
    }
 
    std::string s;
@@ -1320,13 +1320,13 @@ separator=",";
 auto sepComma = [separator](int i){std::cout << i << separator;};  
      
 std::for_each(vecInt.begin(), vecInt.end(), sepColon);  
-std::cout << std::endl;
+std::cout << '\n';
       
 std::for_each(vecInt.begin(), vecInt.end(), sepMinus);  
-std::cout << std::endl;
+std::cout << '\n';
      
 std::for_each(vecInt.begin(), vecInt.end(), sepComma);  
-std::cout << std::endl;
+std::cout << '\n';
 ```
 
 Im folgenden Beispiel wird eine Variable 'counter' von der Lambda-Funktion verändert. Gleichzeitig konserviert die Lambda-Funktion ihren Kontext, so dass am Ende der Counter entsprechend gesetzt ist.  
@@ -1339,7 +1339,7 @@ auto incrementLambda = [&counter](){counter+=1;};
 incrementLambda();
 incrementLambda();
 
-std::cout << "counter = " << counter << std::endl;
+std::cout << "counter = " << counter << '\n';
 ```
 
 **Lambda mit Rückgabewert**
@@ -1357,7 +1357,7 @@ auto lambdaRetval = [](int x, int y)->int
 int res = lambdaRetval(2, 4);
 
 std::cout << "result of lambdaRetval: " << res;
-std::cout << std::endl; 
+std::cout << '\n';
 ```
 
 ## bind()
@@ -1380,18 +1380,18 @@ Mit std::bind kann man beispielsweise:
 void myFunction(int val1, int val2, int val3, int val4)
 {
 	std::cout << val1 << ' ' << val2 << ' ' << val3 << ' ' << val4;  
-	std::cout << std::endl;
+	std::cout << '\n';
 }
 
 void myFunction1(int val1, int val2)
 {
 	std::cout << val1 << ' ' << val2;  
-	std::cout << std::endl;
+	std::cout << '\n';
 }
 
 int main()
 {
-	std::cout << "Hallo" << std::endl;
+	std::cout << "Hallo\n";
  
 	int n=7;
 
@@ -1442,8 +1442,8 @@ template<typename... Args> bool istWahr(Args... args)
 int main()
 {
    std::cout << std::boolalpha;
-   std::cout << "istWahr(true) " << istWahr(true) << std::endl;
-   std::cout << "istWahr(true, false) " << istWahr(true, false) << std::endl;
+   std::cout << "istWahr(true) " << istWahr(true) << '\n';
+   std::cout << "istWahr(true, false) " << istWahr(true, false) << '\n';
 }
 
 // >>> istWahr(true) true
@@ -1497,7 +1497,7 @@ Die Syntax lautet:
   
 int main()
 {
-   std::cout << "Hallo" << std::endl;
+   std::cout << "Hallo\n";
   
    // will it work?
    static_assert(sizeof(void*) >= 8, "Wo lebst du? Wir sind hier in der 64-bit Welt");
@@ -1605,13 +1605,13 @@ typename std::enable_if<std::is_integral<T>::value, bool>::type
 
 int main()
 {
-   std::cout << std::endl;
+   std::cout << '\n';
 
    int i = 1;    // code does not compile if type of i is not integral
 
    std::cout << std::boolalpha;
-   std::cout << "i is odd: " << is_odd(i) << std::endl;
-   std::cout << "i is even: " << is_even(i) << std::endl;
+   std::cout << "i is odd: " << is_odd(i) << '\n';
+   std::cout << "i is even: " << is_even(i) << '\n';
    
    return 0;
 }
@@ -1713,12 +1713,12 @@ Ein kurzes Beispiel soll die Erzeugung von Threads mit Hilfe von *std::thread* v
 
 void mul(int x, int y)
 {
-   std::cout << "mul " << x*y << std::endl;
+   std::cout << "mul " << x*y << '\n';
 }
 
 void add(int x, int y)
 {
-   std::cout << "add " << x+y << std::endl;
+   std::cout << "add " << x+y << '\n';
 }
 
 int main()
@@ -1726,7 +1726,7 @@ int main()
    // check the number of concurrent threads allowed
    int num_cores = std::thread::hardware_concurrency();
     
-   std::cout << "threads " << num_cores << std::endl;
+   std::cout << "threads " << num_cores << '\n';
     
    // create threads doing various things
    std::thread th1(mul, 2, 3);
@@ -1767,7 +1767,7 @@ void inc(int id)
     {
         mutex.lock();
         counter++;
-        std::cout << id << "=> " << counter << std::endl;
+        std::cout << id << "=> " << counter << '\n';
         mutex.unlock();
         
         std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -1836,7 +1836,7 @@ void signals()
 
 int main()
 {
-   std::cout << std::endl;
+   std::cout << '\n';
 
    // create two threads 
    std::thread t1(waits);  // waitingForWork should wait for setDataReady
@@ -1975,7 +1975,7 @@ int main()
    // Ermittle jetzt-Zeitpunkt
    end = std::chrono::system_clock::now();
    
-   std::cout << "Ergebnis " << result << std::endl;
+   std::cout << "Ergebnis " << result << '\n';
    
    // (end - start) ergibt Zeitdauer
    int elapsed_seconds = 										  		  	     std::chrono::duration_cast<std::chrono::seconds>(end-start).count();
@@ -2019,7 +2019,7 @@ int main()
     const std::regex base_regex("Haar");
     
     bool found = std::regex_search(haar_str, base_match, base_regex);
-    std::cout << std::boolalpha << "haar_str: found 'Haar' " << found << std::endl;
+    std::cout << std::boolalpha << "haar_str: found 'Haar' " << found << '\n';
     
     if (base_match.ready())
     {
@@ -2029,7 +2029,7 @@ int main()
     }
     
     found = std::regex_search(wurm_str, base_match, base_regex);
-    std::cout << std::boolalpha << "wurm_str: found 'Haar' " << found << std::endl;
+    std::cout << std::boolalpha << "wurm_str: found 'Haar' " << found << '\n';
     
     
         
@@ -2094,12 +2094,12 @@ class Test
 
 void func(Test const&)
 {
-   std::cout << "requires lvalue" << std::endl;
+   std::cout << "requires lvalue\n";
 }
 
 void func(Test&&)
 {
-   std::cout << "requires rvalue" << std::endl;
+   std::cout << "requires rvalue\n";
 }
 
 // pass accepta a rvalue reference as parameter 


### PR DESCRIPTION
`std::endl` implies a flush which is rarely needed (and readers might be confused as to why a flush appears to be needed) and reduces efficiency. It is better (in my opinion) to teach to use '\n' or "\n" and only use flushing when needed (and teach which the cases are).